### PR TITLE
Adding printf

### DIFF
--- a/liquid_crystal_i2c.c
+++ b/liquid_crystal_i2c.c
@@ -10,6 +10,7 @@
 
 #include <avr/io.h>
 #include <util/delay.h>
+#include <stdio.h>
 
 LiquidCrystalDevice_t lq_init(uint8_t address, uint8_t columns, uint8_t rows, uint8_t dotSize)
 {
@@ -89,6 +90,15 @@ void lq_print(struct LiquidCrystalDevice_t* device, char * value)
 		letter = *(++value);
 	}
 };
+
+void lq_printf (LiquidCrystalDevice_t *device, const char *fmt, ...){
+	char buffer[MAX_PRINT_BUFFER];
+	va_list args;
+	va_start (args, fmt);
+	vsnprintf (buffer,MAX_PRINT_BUFFER,fmt, args);
+	lq_print (device, buffer);
+	va_end (args);
+}
 
 void lq_turnOnBacklight(struct LiquidCrystalDevice_t* device)
 {

--- a/liquid_crystal_i2c.h
+++ b/liquid_crystal_i2c.h
@@ -62,6 +62,8 @@
 #define LCD_READ_WRITE_BIT 0b00000010  // Read/Write bit
 #define LCD_REGISTER_SELECT_BIT 0b00000001  // Register select bit
 
+#define MAX_PRINT_BUFFER 100
+
 typedef struct LiquidCrystalDevice_t {
 	uint8_t Address;
 	uint8_t Columns;

--- a/liquid_crystal_i2c.h
+++ b/liquid_crystal_i2c.h
@@ -86,6 +86,8 @@ void lq_turnOffBacklight(struct LiquidCrystalDevice_t* device);
 
 void lq_print(struct LiquidCrystalDevice_t* device, char* value);
 
+void lq_printf(struct LiquidCrystalDevice_t* device, const char* format, ...);
+
 void lq_turnOnDisplay(struct LiquidCrystalDevice_t* device);
 
 void lq_turnOffDisplay(struct LiquidCrystalDevice_t* device);
@@ -124,3 +126,4 @@ void lq_writeDevicePulse(struct LiquidCrystalDevice_t* device, uint8_t value);
 void lq_transmitI2C(struct LiquidCrystalDevice_t* device, uint8_t value);
 
 #endif /* LIQUIDCRYSTALI2CDEVICE_H_ */
+


### PR DESCRIPTION
Adding printf functionality to simplify formatting the output.

Example:
lq_printf (&my_device, "speed: %d kph", 45);